### PR TITLE
[OI] fix variable rendering influenced by "upper" filter

### DIFF
--- a/templates/auditd.conf.j2
+++ b/templates/auditd.conf.j2
@@ -3,24 +3,24 @@
 #
 
 log_file = {{ auditd_log_file }}
-log_format = {{ auditd_log_format | upper }}
+log_format = {{ auditd_log_format }}
 log_group = {{ auditd_log_group }}
 priority_boost = {{ auditd_priority_boost }}
-flush = {{ auditd_flush | upper }}
+flush = {{ auditd_flush }}
 freq = {{ auditd_frequency }}
 num_logs = {{ auditd_num_logs }}
 disp_qos = {{ auditd_disp_qos }}
 dispatcher = {{ auditd_dispatcher }}
-name_format = {{ auditd_name_format | upper }}
+name_format = {{ auditd_name_format }}
 max_log_file = {{ auditd_max_log_file }}
-max_log_file_action = {{ auditd_max_log_file_action | upper }}
+max_log_file_action = {{ auditd_max_log_file_action }}
 space_left = {{ auditd_space_left }}
-space_left_action = {{ auditd_space_left_action | upper }}
+space_left_action = {{ auditd_space_left_action }}
 action_mail_acct = {{ auditd_action_mail_acct }}
 admin_space_left = {{ auditd_admin_space_left }}
-admin_space_left_action = {{ auditd_admin_space_left_action | upper }}
-disk_full_action = {{ auditd_disk_full_action | upper }}
-disk_error_action = {{ auditd_disk_error_action | upper }}
+admin_space_left_action = {{ auditd_admin_space_left_action }}
+disk_full_action = {{ auditd_disk_full_action }}
+disk_error_action = {{ auditd_disk_error_action }}
 tcp_listen_queue = {{ auditd_tcp_listen_queue }}
 tcp_max_per_addr = {{ auditd_tcp_max_per_addr }}
 tcp_client_max_idle = {{ auditd_tcp_client_max_idle }}


### PR DESCRIPTION
According to
https://manpages.debian.org/testing/auditd/auditd.conf.5.en.html, `All
option names and values are case insensitive.`.

However, CIS-CAT scan results fail when values are uppercase. This
is the sole motivation for this change. Clearly, CIS config assessment
tool needs to be fixed. But I suspect it'll be far quicker and easier to
make option values lowercase since that's valid too.

Please consider this change (which doesn't add any "real" value). ;-)